### PR TITLE
[rules_docker] Remove python 2 toolchain support

### DIFF
--- a/toolchains/BUILD
+++ b/toolchains/BUILD
@@ -12,28 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
-
 package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
 py_runtime(
-    name = "default_container_py2_runtime",
-    interpreter_path = "/usr/bin/python",
-    python_version = "PY2",
-)
-
-py_runtime(
     name = "default_container_py3_runtime",
     interpreter_path = "/usr/bin/python3",
     python_version = "PY3",
-)
-
-py_runtime_pair(
-    name = "default_container_py_runtime_pair",
-    py2_runtime = ":default_container_py2_runtime",
-    py3_runtime = ":default_container_py3_runtime",
 )
 
 # A toolchain to run python outputs inside a container.
@@ -45,7 +31,7 @@ toolchain(
     exec_compatible_with = [
         "@io_bazel_rules_docker//platforms:run_in_container",
     ],
-    toolchain = ":default_container_py_runtime_pair",
+    toolchain = ":default_container_py3_runtime",
     toolchain_type = "@bazel_tools//tools/python:toolchain_type",
 )
 


### PR DESCRIPTION
This is deprecated in bazel 8. Remove it.