### PR TITLE
[rules_docker] Use argfiles for create_image_config

### DIFF
--- a/container/go/cmd/create_image_config/create_image_config.go
+++ b/container/go/cmd/create_image_config/create_image_config.go
@@ -23,48 +23,62 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/bazelbuild/rules_docker/container/go/pkg/compat"
 	"github.com/bazelbuild/rules_docker/container/go/pkg/utils"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
-var (
-	baseConfig         = flag.String("baseConfig", "", "The base image config.")
-	baseManifest       = flag.String("baseManifest", "", "The base image manifest.")
-	outputConfig       = flag.String("outputConfig", "", "The output image config file to generate.")
-	outputManifest     = flag.String("outputManifest", "", "The output manifest file to generate.")
-	creationTimeString = flag.String("creationTime", "", "The creation timestamp. Acceptable formats: Integer or floating point seconds since Unix Epoch, RFC 3339 date/time.")
-	user               = flag.String("user", "", "The username to run the commands under.")
-	workdir            = flag.String("workdir", "", "Set the working directory of the layer.")
-	nullEntryPoint     = flag.Bool("nullEntryPoint", false, "If true, Entrypoint will be set to null.")
-	nullCmd            = flag.Bool("nullCmd", false, "If true, Cmd will be set to null.")
-	architecture       = flag.String("architecture", "amd64", "The architecture of the docker image.")
-	operatingSystem    = flag.String("operatingSystem", "linux", "Operating system to create docker image for, eg. linux.")
-	osVersion          = flag.String("osVersion", "", "Operating system version to create docker image for (primarily for windows).")
-	labelsArray        utils.ArrayStringFlags
-	ports              utils.ArrayStringFlags
-	volumes            utils.ArrayStringFlags
-	entrypointPrefix   utils.ArrayStringFlags
-	env                utils.ArrayStringFlags
-	command            utils.ArrayStringFlags
-	entrypoint         utils.ArrayStringFlags
-	layerDigestFile    utils.ArrayStringFlags
-	stampInfoFile      utils.ArrayStringFlags
-)
-
 func main() {
-	flag.Var(&labelsArray, "labels", "Augment the Label of the previous layer.")
-	flag.Var(&ports, "ports", "Augment the ExposedPorts of the previous layer.")
-	flag.Var(&volumes, "volumes", "Augment the Volumes of the previous layer.")
-	flag.Var(&entrypointPrefix, "entrypointPrefix", "Prefix the Entrypoint with the specified arguments.")
-	flag.Var(&env, "env", "Augment the Env of the previous layer.")
-	flag.Var(&command, "command", "Override the Cmd of the previous layer.")
-	flag.Var(&entrypoint, "entrypoint", "Override the Entrypoint of the previous layer.")
-	flag.Var(&layerDigestFile, "layerDigestFile", "Layer sha256 hashes that make up this image. The order that these layers are specified matters.")
-	flag.Var(&stampInfoFile, "stampInfoFile", "A list of files from which to read substitutions to make in the provided fields.")
+	var flagSet *flag.FlagSet = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
-	flag.Parse()
+	var (
+		baseConfig         = flagSet.String("baseConfig", "", "The base image config.")
+		baseManifest       = flagSet.String("baseManifest", "", "The base image manifest.")
+		outputConfig       = flagSet.String("outputConfig", "", "The output image config file to generate.")
+		outputManifest     = flagSet.String("outputManifest", "", "The output manifest file to generate.")
+		creationTimeString = flagSet.String("creationTime", "", "The creation timestamp. Acceptable formats: Integer or floating point seconds since Unix Epoch, RFC 3339 date/time.")
+		user               = flagSet.String("user", "", "The username to run the commands under.")
+		workdir            = flagSet.String("workdir", "", "Set the working directory of the layer.")
+		nullEntryPoint     = flagSet.Bool("nullEntryPoint", false, "If true, Entrypoint will be set to null.")
+		nullCmd            = flagSet.Bool("nullCmd", false, "If true, Cmd will be set to null.")
+		architecture       = flagSet.String("architecture", "amd64", "The architecture of the docker image.")
+		operatingSystem    = flagSet.String("operatingSystem", "linux", "Operating system to create docker image for, eg. linux.")
+		osVersion          = flagSet.String("osVersion", "", "Operating system version to create docker image for (primarily for windows).")
+		labelsArray        utils.ArrayStringFlags
+		ports              utils.ArrayStringFlags
+		volumes            utils.ArrayStringFlags
+		entrypointPrefix   utils.ArrayStringFlags
+		env                utils.ArrayStringFlags
+		command            utils.ArrayStringFlags
+		entrypoint         utils.ArrayStringFlags
+		layerDigestFile    utils.ArrayStringFlags
+		stampInfoFile      utils.ArrayStringFlags
+	)
+	flagSet.Var(&labelsArray, "labels", "Augment the Label of the previous layer.")
+	flagSet.Var(&ports, "ports", "Augment the ExposedPorts of the previous layer.")
+	flagSet.Var(&volumes, "volumes", "Augment the Volumes of the previous layer.")
+	flagSet.Var(&entrypointPrefix, "entrypointPrefix", "Prefix the Entrypoint with the specified arguments.")
+	flagSet.Var(&env, "env", "Augment the Env of the previous layer.")
+	flagSet.Var(&command, "command", "Override the Cmd of the previous layer.")
+	flagSet.Var(&entrypoint, "entrypoint", "Override the Entrypoint of the previous layer.")
+	flagSet.Var(&layerDigestFile, "layerDigestFile", "Layer sha256 hashes that make up this image. The order that these layers are specified matters.")
+	flagSet.Var(&stampInfoFile, "stampInfoFile", "A list of files from which to read substitutions to make in the provided fields.")
+
+	var allArgs []string
+	for _, arg := range os.Args[1:] {
+		if strings.HasPrefix(arg, "@") {
+			content, err := os.ReadFile(arg[1:])
+			if err != nil {
+				log.Fatalf("Failed to read argfile %s: %v", arg, err)
+			}
+			allArgs = append(allArgs, strings.Split(string(content), "\n")...)
+		} else {
+			allArgs = append(allArgs, arg)
+		}
+	}
+	flagSet.Parse(allArgs)
 
 	if *outputConfig == "" {
 		log.Fatalln("Required option -outputConfig was not specified.")

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -189,6 +189,8 @@ def _add_create_image_config_args(
     if ctx.attr.launcher:
         args.add("-entrypointPrefix", ctx.file.launcher.basename, format = "/%s")
         args.add_all(ctx.attr.launcher_args, before_each = "-entrypointPrefix")
+    args.use_param_file(param_file_arg = "@%s", use_always=False)
+    args.set_param_file_format("multiline")
 
 def _format_legacy_label(t):
     return ("--labels=%s=%s" % (t[0], t[1]))


### PR DESCRIPTION
When updating some packages to use bzlmod, we ran into a problem with the new paths in external/ being too long for create_image_config. Instead, make it work with an argfile, and make bazel pass an argfile when invoking this program.