### PR TITLE
Change param file handling for java and in image creator

### DIFF
--- a/container/go/cmd/create_image_config/create_image_config.go
+++ b/container/go/cmd/create_image_config/create_image_config.go
@@ -68,8 +68,8 @@ func main() {
 
 	var allArgs []string
 	for _, arg := range os.Args[1:] {
-		if strings.HasPrefix(arg, "@") {
-			content, err := os.ReadFile(arg[1:])
+		if strings.HasPrefix(arg, "@@") {
+			content, err := os.ReadFile(arg[2:])
 			if err != nil {
 				log.Fatalf("Failed to read argfile %s: %v", arg, err)
 			}

--- a/container/image.bzl
+++ b/container/image.bzl
@@ -189,7 +189,7 @@ def _add_create_image_config_args(
     if ctx.attr.launcher:
         args.add("-entrypointPrefix", ctx.file.launcher.basename, format = "/%s")
         args.add_all(ctx.attr.launcher_args, before_each = "-entrypointPrefix")
-    args.use_param_file(param_file_arg = "@%s", use_always=False)
+    args.use_param_file(param_file_arg = "@@%s", use_always=False)
     args.set_param_file_format("multiline")
 
 def _format_legacy_label(t):

--- a/java/image.bzl
+++ b/java/image.bzl
@@ -201,7 +201,7 @@ def _jar_app_layer_impl(ctx):
         "/usr/bin/java",
         "-cp",
         # Support optionally passing the classpath as a file.
-        "@" + classpath_path if ctx.attr._classpath_as_file else classpath,
+        "@" + classpath_path if ctx.attr.classpath_as_file else classpath,
     ] + jvm_flags + ([ctx.attr.main_class] + args if ctx.attr.main_class != "" else [])
 
     file_map = {
@@ -245,7 +245,8 @@ jar_app_layer = rule(
         "deps": attr.label_list(),
 
         # Whether the classpath should be passed as a file.
-        "_classpath_as_file": attr.bool(default = False),
+        # Disable for the uncommon case where it causes issues.
+        "classpath_as_file": attr.bool(default = True),
         "_jdk": attr.label(
             default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
             providers = [java_common.JavaRuntimeInfo],


### PR DESCRIPTION
We ran into an issue recently where the length of classpaths after flipping to bzlmod, with its longer paths, caused failure at runtime because the classpath argument was over the default limits for linux. This just sets the classpath being in a file as the default (and exposes a flag to turn it off). The core functionality was already present.

We were previously using '@<path>' to indicate arg files in the create_image_config program. This was changed to @@ because the entrypoint arguments that are passed in might *also* start with a single '@' because they are param files meant for the JVM