### PR TITLE
Don't register go toolchains automatically

### DIFF
--- a/repositories/go_repositories.bzl
+++ b/repositories/go_repositories.bzl
@@ -30,9 +30,9 @@ def go_deps():
     'repositories' in //repositories:repositories.bzl have been imported
     already.
     """
-    go_rules_dependencies()
-    go_register_toolchains()
-    gazelle_dependencies()
+    #go_rules_dependencies()
+    #go_register_toolchains()
+    gazelle_dependencies(go_sdk = "go_sdk")
     excludes = native.existing_rules().keys()
     if "com_github_google_go_containerregistry" not in excludes:
         go_repository(


### PR DESCRIPTION
This mostly made sense before, but this unconditional registration of toolchains is causing some issues if you aren't registering the toolchain within WORKSPACE and are doing it in MODULE.bazel