### PR TITLE
[bazel9] Fixes for bazel 9 and newer rules_*

### DIFF
--- a/container/push.bzl
+++ b/container/push.bzl
@@ -225,15 +225,15 @@ def container_push(name, format, image, registry, repository, **kwargs):
         registry = registry,
         repository = repository,
         extension = select({
-            "@bazel_tools//src/conditions:host_windows": ".bat",
+            "@platforms//os:windows": ".bat",
             "//conditions:default": "",
         }),
         tag_tpl = select({
-            "@bazel_tools//src/conditions:host_windows": Label("//container:push-tag.bat.tpl"),
+            "@platforms//os:windows": Label("//container:push-tag.bat.tpl"),
             "//conditions:default": Label("//container:push-tag.sh.tpl"),
         }),
         windows_paths = select({
-            "@bazel_tools//src/conditions:host_windows": True,
+            "@platforms//os:windows": True,
             "//conditions:default": False,
         }),
         **kwargs

--- a/docker/package_managers/install_pkgs.bzl
+++ b/docker/package_managers/install_pkgs.bzl
@@ -141,7 +141,7 @@ def _impl(ctx, image_tar = None, installables_tar = None, installation_cleanup_c
         use_default_shell_env = True,
     )
 
-    return struct()
+    return []
 
 _attrs = {
     "image_tar": attr.label(

--- a/docker/util/run.bzl
+++ b/docker/util/run.bzl
@@ -95,7 +95,7 @@ def _extract_impl(
         use_default_shell_env = True,
     )
 
-    return struct()
+    return []
 
 _extract_attrs = {
     "commands": attr.string_list(
@@ -227,7 +227,7 @@ def _commit_impl(
         use_default_shell_env = True,
     )
 
-    return struct()
+    return []
 
 _commit_attrs = {
     "commands": attr.string_list(


### PR DESCRIPTION
Few small changes because things got deprecated in bazel 9:
- Don't use the old windows host selector, use the one in platforms
- You can't return a struct from a rule impl. Not sure what this was supposed to do tbh.