### PR TITLE
Bake image tag into manifest during incremental load

### DIFF
--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -211,10 +211,12 @@ EOF
   tar cPh "${MISSING[@]}" | "${DOCKER}" ${DOCKER_FLAGS} load
 }
 
-# No-op: images are now tagged during import_config via the manifest's
-# RepoTags. Kept so the generated "tag_layer" statements still resolve.
+# The image is already tagged during import_config (via the manifest's
+# RepoTags), so this no longer runs "docker tag". It only logs the tag, since
+# "docker load" under the containerd image store omits it from its output.
 function tag_layer() {
-  :
+  local TAG="$1"
+  echo "Tagged ${TAG} during load"
 }
 
 function read_variables() {

--- a/container/incremental_load.sh.tpl
+++ b/container/incremental_load.sh.tpl
@@ -122,10 +122,13 @@ function find_diffbase() {
   echo "${TOTAL_DIFF_IDS[@]:0:${LEGACY_COUNT}}"
 }
 
+# $2 is the image tag; it is baked into manifest.json's RepoTags below, so a
+# separate "docker tag" step (tag_layer) is no longer needed.
 function import_config() {
   # Create an image from the image configuration file.
   local name="${RUNFILES}/$1"
-  shift 1
+  local TAG="$2"
+  shift 2
 
   local tmp_dir="$(mktemp -d)"
   echo "${tmp_dir}" >> "${TEMP_FILES}"
@@ -196,7 +199,7 @@ function import_config() {
 [{
    "Config": "config.json",
    "Layers": [$(join_by , ${ALL_QUOTED[@]})],
-   "RepoTags": []
+   "RepoTags": ["$TAG"]
 }]
 EOF
 
@@ -208,12 +211,10 @@ EOF
   tar cPh "${MISSING[@]}" | "${DOCKER}" ${DOCKER_FLAGS} load
 }
 
+# No-op: images are now tagged during import_config via the manifest's
+# RepoTags. Kept so the generated "tag_layer" statements still resolve.
 function tag_layer() {
-  local name="$(cat "${RUNFILES}/$2")"
-
-  local TAG="$1"
-  echo "Tagging ${name} as ${TAG}"
-  "${DOCKER}" ${DOCKER_FLAGS} tag sha256:${name} ${TAG}
+  :
 }
 
 function read_variables() {

--- a/container/layer_tools.bzl
+++ b/container/layer_tools.bzl
@@ -232,11 +232,17 @@ def incremental_load(
 
         pairs = zip(image["diff_id"], image["unzipped_layer"])
 
-        # Import the config and the subset of layers not present
-        # in the daemon.
+        # Turn stamp variable references into bash variables. The only legal
+        # use of '{' in a tag is for stamp variables ('$' is not allowed).
+        tag_reference = tag if not stamp else tag.replace("{", "${")
+
+        # Import the config and the subset of layers not present in the
+        # daemon. The tag is passed through so it can be baked into the
+        # manifest's RepoTags during the load, which makes tag_layer a no-op.
         load_statements += [
-            "import_config '%s' %s" % (
+            "import_config '%s' \"%s\" %s" % (
                 _get_runfile_path(ctx, image["config"]),
+                tag_reference,
                 " ".join([
                     "'%s' '%s'" % (
                         _get_runfile_path(ctx, diff_id),
@@ -247,13 +253,11 @@ def incremental_load(
             ),
         ]
 
-        # Now tag the imported config with the specified tag.
-        tag_reference = tag if not stamp else tag.replace("{", "${")
+        # tag_layer is a no-op now (the manifest already carries the tag), but
+        # the statement is still emitted so the generated script stays in sync
+        # with the template's %{tag_statements} substitution.
         tag_statements += [
             "tag_layer \"%s\" '%s'" % (
-                # Turn stamp variable references into bash variables.
-                # It is notable that the only legal use of '{' in a
-                # tag would be for stamp variables, '$' is not allowed.
                 tag_reference,
                 _get_runfile_path(ctx, image["config_digest"]),
             ),

--- a/contrib/extract_image_id.py
+++ b/contrib/extract_image_id.py
@@ -24,14 +24,18 @@ import tarfile
 
 
 def get_id(tar_path):
-  """Extracts the id of a docker image from its tarball.
+  """Extracts the name of a docker image from its tarball.
+
+  Since Docker Engine moved to the containerd image store (Docker 1.29+), the
+  image id can no longer be reliably derived from the config filename, so this
+  returns the image name from the manifest's RepoTags instead.
 
   Args:
     tar_path: str path to the tarball
 
 
   Returns:
-    str id of the image
+    str name of the image
 
   """
   tar = tarfile.open(tar_path, mode="r")
@@ -51,13 +55,10 @@ def get_id(tar_path):
   # Get the manifest dictionary from JSON
   manifest = decoder.decode(manifest)[0]
 
-  # The name of the config file is of the form <image_id>.json
-  config_file = manifest["Config"]
+  # Read the image name from the manifest's RepoTags.
+  image_name = manifest["RepoTags"][0]
 
-  # Get the id
-  id_ = config_file.split(".")[0]
-
-  return id_
+  return image_name
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Cleaned-up port of [bazelbuild/rules_docker#2290](https://github.com/bazelbuild/rules_docker/pull/2290) (closed upstream), targeting our `discord` integration branch.

## Why
Docker Engine 1.29+ uses the containerd image store, where an image id can no longer be reliably derived from the config filename in a saved tarball. `incremental_load`'s separate `docker tag` step and `extract_image_id.py`'s "config filename is the id" assumption both break.

## What
- **`incremental_load.sh.tpl`** — `import_config` now takes the tag as `$2` and bakes it into the final manifest's `RepoTags`, so the image is named at load time. `tag_layer` becomes a no-op.
- **`layer_tools.bzl`** — passes the tag through to `import_config`.
- **`extract_image_id.py`** — reads the image name from `RepoTags[0]` instead of the config filename.

## Cleanups vs. the original PR
- **Reverted the `sequence_exists()` changes.** That function only builds a throwaway manifest to probe whether a layer sequence already exists in the daemon, so it never needed the tag. The original was also buggy: it passed the tag as a trailing arg but read `local TAG="$2"` (a diff-id) and let `diff_ids="$@"` fold the tag into the `Layers` list. Real tagging happens in `import_config`'s final manifest, which is kept.
- Made `tag_layer()` a clean no-op and dropped its dead locals.
- De-duplicated `tag_reference` in `layer_tools.bzl`.
- Removed the author-specific `[CAAS]` markers, `~~strikethrough~~` docstrings, a typo, and trailing whitespace.

The monorepo's `MODULE.bazel` pin is **not** updated yet — that'll be a follow-up once this lands on `discord`.